### PR TITLE
Bin Archive Hotfix

### DIFF
--- a/GFDLibrary/Common/Archive.cs
+++ b/GFDLibrary/Common/Archive.cs
@@ -31,7 +31,9 @@ namespace GFDLibrary.Common
             using ( var reader = new ArchiveReader( stream, true ))
             {
                 // Read first entry, if this succeeds it's probably a valid archive
-                return reader.ReadEntryHeader( out var dummy );
+                bool isValid = reader.ReadEntryHeader( out var dummy );
+                stream.Position = 0;
+                return isValid;
             }
         }
 


### PR DESCRIPTION
The bin archive validity check tests the archive by trying to read an entry.
However, it doesn't reset the stream position, which causes the first entry of any bin archive to be skipped on load (when the check is successful).
This in turn causes crashes when the game tries to load an edited bin file.

Very quick fix, worked when tested on a few files.