### PR TITLE
Add "Convert to material preset" feature

### DIFF
--- a/GFDLibrary/Materials/Material.cs
+++ b/GFDLibrary/Materials/Material.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Numerics;
 using GFDLibrary.IO;
 using GFDLibrary.Models;
+using GFDLibrary.Models.Conversion;
 
 namespace GFDLibrary.Materials
 {
@@ -526,6 +527,56 @@ namespace GFDLibrary.Materials
                 foreach ( var attribute in Attributes )
                     MaterialAttribute.Write( writer, attribute );
             }
+        }
+
+        public static Material ConvertToMaterialPreset(Material material, ModelPackConverterOptions options)
+        {
+            Material newMaterial = null;
+
+            var materialName = material.Name;
+            var diffuseTexture = material.DiffuseMap;
+            var shadowTexture = material.ShadowMap;
+            if (shadowTexture == null)
+                shadowTexture = material.DiffuseMap;
+            var specularTexture = material.SpecularMap;
+            if (specularTexture == null)
+                specularTexture = material.DiffuseMap;
+
+            switch (options.MaterialPreset)
+            {
+                case MaterialPreset.FieldTerrain:
+                    {
+                        newMaterial = MaterialFactory.CreateFieldTerrainMaterial(materialName, diffuseTexture.Name, false);
+                    }
+                    break;
+                case MaterialPreset.FieldTerrainCastShadow:
+                    {
+                        newMaterial = MaterialFactory.CreateFieldTerrainCastShadowMaterial(materialName, diffuseTexture.Name, false);
+                    }
+                    break;
+                case MaterialPreset.CharacterSkinP5:
+                case MaterialPreset.CharacterSkinFB:
+                    {
+                        if (options.MaterialPreset == MaterialPreset.CharacterSkinP5)
+                            newMaterial = MaterialFactory.CreateCharacterSkinP5Material(materialName, diffuseTexture.Name, shadowTexture.Name, false);
+                        else
+                            newMaterial = MaterialFactory.CreateCharacterSkinFBMaterial(materialName, diffuseTexture.Name, shadowTexture.Name, false);
+                    }
+                    break;
+
+                case MaterialPreset.PersonaSkinP5:
+                    {
+                        newMaterial = MaterialFactory.CreatePersonaSkinP5Material(materialName, diffuseTexture.Name, specularTexture.Name, shadowTexture.Name);
+                    }
+                    break;
+
+                case MaterialPreset.CharacterClothP4D:
+                    {
+                        newMaterial = MaterialFactory.CreateCharacterClothP4DMaterial(materialName, diffuseTexture.Name, false);
+                    }
+                    break;
+            }
+            return newMaterial;
         }
     }
 

--- a/GFDLibrary/Materials/MaterialDictionary.cs
+++ b/GFDLibrary/Materials/MaterialDictionary.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Assimp.Configs;
 using GFDLibrary.IO;
+using GFDLibrary.Models.Conversion;
+using GFDLibrary.Textures;
 
 namespace GFDLibrary.Materials
 {
@@ -26,6 +30,63 @@ namespace GFDLibrary.Materials
         {
             get => mDictionary[name];
             set => mDictionary[name] = value;
+        }
+
+        public static MaterialDictionary ConvertToMaterialPreset( MaterialDictionary materialDictionary, ModelPackConverterOptions options )
+        {
+            Material newMaterial = null;
+            var newMaterialDictionary = new MaterialDictionary(options.Version);
+
+            foreach (var material in materialDictionary.Materials)
+            {
+                Console.WriteLine(materialDictionary.Materials);
+                var materialName = material.Name;
+                var diffuseTexture = material.DiffuseMap;
+                var shadowTexture = material.ShadowMap;
+                if (shadowTexture == null)
+                    shadowTexture = material.DiffuseMap;
+                var specularTexture = material.SpecularMap;
+                if (specularTexture == null)
+                    specularTexture = material.DiffuseMap;
+
+                switch (options.MaterialPreset)
+                {
+                    case MaterialPreset.FieldTerrain:
+                        {
+                            newMaterial = MaterialFactory.CreateFieldTerrainMaterial(materialName, diffuseTexture.Name, false);
+                        }
+                        break;
+                    case MaterialPreset.FieldTerrainCastShadow:
+                        {
+                            newMaterial = MaterialFactory.CreateFieldTerrainCastShadowMaterial(materialName, diffuseTexture.Name, false);
+                        }
+                        break;
+                    case MaterialPreset.CharacterSkinP5:
+                    case MaterialPreset.CharacterSkinFB:
+                        {
+                            if (options.MaterialPreset == MaterialPreset.CharacterSkinP5)
+                                newMaterial = MaterialFactory.CreateCharacterSkinP5Material(materialName, diffuseTexture.Name, shadowTexture.Name, false);
+                            else
+                                newMaterial = MaterialFactory.CreateCharacterSkinFBMaterial(materialName, diffuseTexture.Name, shadowTexture.Name, false);
+                        }
+                        break;
+
+                    case MaterialPreset.PersonaSkinP5:
+                        {
+                            newMaterial = MaterialFactory.CreatePersonaSkinP5Material(materialName, diffuseTexture.Name, specularTexture.Name, shadowTexture.Name);
+                        }
+                        break;
+
+                    case MaterialPreset.CharacterClothP4D:
+                        {
+                            newMaterial = MaterialFactory.CreateCharacterClothP4DMaterial(materialName, diffuseTexture.Name, false);
+                        }
+                        break;
+                }
+                newMaterialDictionary.Add(newMaterial);
+            }
+
+            return newMaterialDictionary;
         }
 
         public void ReplaceWith( MaterialDictionary other )

--- a/GFDLibrary/Materials/MaterialDictionary.cs
+++ b/GFDLibrary/Materials/MaterialDictionary.cs
@@ -2,10 +2,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Assimp.Configs;
 using GFDLibrary.IO;
 using GFDLibrary.Models.Conversion;
-using GFDLibrary.Textures;
 
 namespace GFDLibrary.Materials
 {

--- a/GFDLibrary/Materials/MaterialDictionary.cs
+++ b/GFDLibrary/Materials/MaterialDictionary.cs
@@ -87,24 +87,24 @@ namespace GFDLibrary.Materials
             return newMaterialDictionary;
         }
 
-        public void ReplaceWith( MaterialDictionary other )
+        public void ReplaceWith(MaterialDictionary other)
         {
-            foreach ( var material in other )
+            foreach (var material in other)
             {
                 // Don't replace the material if we're replacing a normal material with a preset one.
-                if ( !ContainsKey(material.Key) || !material.Value.IsPresetMaterial || this[ material.Key ].IsPresetMaterial )
+                if (!ContainsKey(material.Key) || !material.Value.IsPresetMaterial || this[material.Key].IsPresetMaterial)
                     this[material.Key] = material.Value;
             }
 
             var toRemove = new List<string>();
-            foreach ( var material in this )
+            foreach (var material in this)
             {
-                if ( !other.TryGetMaterial( material.Key, out _ ) )
-                    toRemove.Add( material.Key );
+                if (!other.TryGetMaterial(material.Key, out _))
+                    toRemove.Add(material.Key);
             }
 
-            foreach ( string s in toRemove )
-                Remove( s );
+            foreach (string s in toRemove)
+                Remove(s);
         }
 
         internal override void Read( ResourceReader reader, long endPosition = -1 )

--- a/GFDLibrary/Materials/MaterialDictionary.cs
+++ b/GFDLibrary/Materials/MaterialDictionary.cs
@@ -37,7 +37,6 @@ namespace GFDLibrary.Materials
 
             foreach (var material in materialDictionary.Materials)
             {
-                Console.WriteLine(materialDictionary.Materials);
                 var materialName = material.Name;
                 var diffuseTexture = material.DiffuseMap;
                 var shadowTexture = material.ShadowMap;

--- a/GFDStudio/GUI/DataViewNodes/MaterialDictionaryViewNode.cs
+++ b/GFDStudio/GUI/DataViewNodes/MaterialDictionaryViewNode.cs
@@ -1,7 +1,11 @@
-﻿using System.IO;
+﻿using System;
+using System.Data.Common;
+using System.IO;
 using System.Windows.Forms;
 using GFDLibrary;
 using GFDLibrary.Materials;
+using GFDLibrary.Models.Conversion;
+using GFDStudio.GUI.Forms;
 using Ookii.Dialogs;
 
 namespace GFDStudio.GUI.DataViewNodes
@@ -20,7 +24,7 @@ namespace GFDStudio.GUI.DataViewNodes
 
         protected override void InitializeCore()
         {
-            RegisterExportHandler<MaterialDictionary>( path => Data.Save(  path ) );
+            RegisterExportHandler<MaterialDictionary>( path => Data.Save( path ) );
             RegisterReplaceHandler<MaterialDictionary>( Resource.Load<MaterialDictionary> );
             RegisterAddHandler<Material>( path => Data.Add( Resource.Load<Material>( path ) ) );
             RegisterCustomHandler( "Add", "New material", () =>
@@ -28,6 +32,7 @@ namespace GFDStudio.GUI.DataViewNodes
                 Data.Add( new Material( "New material" ) );
                 InitializeView( true );
             } );
+            RegisterCustomHandler("Convert to", "Material preset", () => { ConvertToMaterialPreset(); });
             RegisterCustomHandler( "Export", "All", () =>
             {
                 using ( var dialog = new VistaFolderBrowserDialog() )
@@ -48,6 +53,22 @@ namespace GFDStudio.GUI.DataViewNodes
 
                 return materialDictionary;
             } );
+        }
+
+        private void ConvertToMaterialPreset()
+        {
+            using (var dialog = new ModelConverterOptionsDialog(false))
+            {
+                if (dialog.ShowDialog() != DialogResult.OK)
+                    return;
+
+                ModelPackConverterOptions options = new ModelPackConverterOptions()
+                {
+                    MaterialPreset = dialog.MaterialPreset,
+                    Version = dialog.Version
+                };
+                Replace(MaterialDictionary.ConvertToMaterialPreset(Data, options));
+            }
         }
 
         protected override void InitializeViewCore()

--- a/GFDStudio/GUI/DataViewNodes/MaterialViewNode.cs
+++ b/GFDStudio/GUI/DataViewNodes/MaterialViewNode.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Numerics;
+using System.Windows.Forms;
 using GFDLibrary;
 using GFDLibrary.Materials;
 using GFDLibrary.Models;
+using GFDLibrary.Models.Conversion;
+using GFDStudio.GUI.Forms;
 using GFDStudio.GUI.TypeConverters;
 
 namespace GFDStudio.GUI.DataViewNodes
@@ -248,6 +251,7 @@ namespace GFDStudio.GUI.DataViewNodes
         {
             RegisterExportHandler<Material>( path => Data.Save(  path ) );
             RegisterReplaceHandler<Material>( Resource.Load<Material> );
+            RegisterCustomHandler("Convert to", "Material preset", () => { ConvertToMaterialPreset(); });
             RegisterModelUpdateHandler( () =>
             {
                 var material = Data;
@@ -333,6 +337,22 @@ namespace GFDStudio.GUI.DataViewNodes
                     Data.Attributes == null ? new List< MaterialAttribute >() : Data.Attributes,
                     new object[] { new ListItemNameProvider< MaterialAttribute >( ( value, index ) => value.AttributeType.ToString() ) } );
             AddChildNode( AttributesViewNode );
+        }
+
+        private void ConvertToMaterialPreset()
+        {
+            using (var dialog = new ModelConverterOptionsDialog(false))
+            {
+                if (dialog.ShowDialog() != DialogResult.OK)
+                    return;
+
+                ModelPackConverterOptions options = new ModelPackConverterOptions()
+                {
+                    MaterialPreset = dialog.MaterialPreset,
+                    Version = dialog.Version
+                };
+                Replace(Material.ConvertToMaterialPreset(Data, options));
+            }
         }
     }
 }

--- a/GFDStudio/GUI/Forms/MainForm.Designer.cs
+++ b/GFDStudio/GUI/Forms/MainForm.Designer.cs
@@ -44,6 +44,8 @@ namespace GFDStudio.GUI.Forms
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.makeRelativeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.rescaleAnimationPacksInDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.convertAnimationsToP5InDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.convertMaterialInDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mPropertyGrid = new System.Windows.Forms.PropertyGrid();
             this.mContentPanel = new System.Windows.Forms.Panel();
             this.tabControl1 = new System.Windows.Forms.TabControl();
@@ -55,7 +57,6 @@ namespace GFDStudio.GUI.Forms
             this.mAnimationStopButton = new System.Windows.Forms.Button();
             this.mAnimationPlaybackButton = new System.Windows.Forms.Button();
             this.mAnimationTrackBar = new System.Windows.Forms.TrackBar();
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.mMainMenuStrip.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
@@ -147,9 +148,10 @@ namespace GFDStudio.GUI.Forms
             this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.makeRelativeToolStripMenuItem,
             this.rescaleAnimationPacksInDirectoryToolStripMenuItem,
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem});
+            this.convertAnimationsToP5InDirectoryToolStripMenuItem,
+            this.convertMaterialInDirectoryToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
             this.toolsToolStripMenuItem.Text = "Tools";
             // 
             // makeRelativeToolStripMenuItem
@@ -165,6 +167,20 @@ namespace GFDStudio.GUI.Forms
             this.rescaleAnimationPacksInDirectoryToolStripMenuItem.Size = new System.Drawing.Size(327, 22);
             this.rescaleAnimationPacksInDirectoryToolStripMenuItem.Text = "Rescale/Reposition animation packs in directory";
             this.rescaleAnimationPacksInDirectoryToolStripMenuItem.Click += new System.EventHandler(this.HandleRescaleAnimationsToolStripMenuItemClick);
+            // 
+            // convertAnimationsToP5InDirectoryToolStripMenuItem
+            // 
+            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Name = "convertAnimationsToP5InDirectoryToolStripMenuItem";
+            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Size = new System.Drawing.Size(327, 22);
+            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Text = "Convert P5R animations to P5 in directory";
+            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Click += new System.EventHandler(this.HandleConvertAnimationsToolStripMenuItemClick);
+            // 
+            // convertMaterialInDirectoryToolStripMenuItem
+            // 
+            this.convertMaterialInDirectoryToolStripMenuItem.Name = "convertMaterialInDirectoryToolStripMenuItem";
+            this.convertMaterialInDirectoryToolStripMenuItem.Size = new System.Drawing.Size(327, 22);
+            this.convertMaterialInDirectoryToolStripMenuItem.Text = "Convert model materials in directory";
+            this.convertMaterialInDirectoryToolStripMenuItem.Click += new System.EventHandler(this.HandleConvertMaterialsToolStripMenuItemClick);
             // 
             // mPropertyGrid
             // 
@@ -255,7 +271,7 @@ namespace GFDStudio.GUI.Forms
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 16.66667F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 70F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 127F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 139F));
             this.tableLayoutPanel1.Controls.Add(this.mAnimationStopButton, 7, 0);
             this.tableLayoutPanel1.Controls.Add(this.mAnimationPlaybackButton, 6, 0);
             this.tableLayoutPanel1.Controls.Add(this.mAnimationTrackBar, 0, 0);
@@ -269,9 +285,9 @@ namespace GFDStudio.GUI.Forms
             // mAnimationStopButton
             // 
             this.mAnimationStopButton.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.mAnimationStopButton.Location = new System.Drawing.Point(595, 3);
+            this.mAnimationStopButton.Location = new System.Drawing.Point(583, 3);
             this.mAnimationStopButton.Name = "mAnimationStopButton";
-            this.mAnimationStopButton.Size = new System.Drawing.Size(127, 29);
+            this.mAnimationStopButton.Size = new System.Drawing.Size(139, 29);
             this.mAnimationStopButton.TabIndex = 2;
             this.mAnimationStopButton.Text = "Stop";
             this.mAnimationStopButton.UseVisualStyleBackColor = true;
@@ -280,7 +296,7 @@ namespace GFDStudio.GUI.Forms
             // mAnimationPlaybackButton
             // 
             this.mAnimationPlaybackButton.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.mAnimationPlaybackButton.Location = new System.Drawing.Point(525, 3);
+            this.mAnimationPlaybackButton.Location = new System.Drawing.Point(513, 3);
             this.mAnimationPlaybackButton.Name = "mAnimationPlaybackButton";
             this.mAnimationPlaybackButton.Size = new System.Drawing.Size(64, 29);
             this.mAnimationPlaybackButton.TabIndex = 0;
@@ -293,15 +309,8 @@ namespace GFDStudio.GUI.Forms
             this.mAnimationTrackBar.Dock = System.Windows.Forms.DockStyle.Fill;
             this.mAnimationTrackBar.Location = new System.Drawing.Point(3, 3);
             this.mAnimationTrackBar.Name = "mAnimationTrackBar";
-            this.mAnimationTrackBar.Size = new System.Drawing.Size(516, 29);
+            this.mAnimationTrackBar.Size = new System.Drawing.Size(504, 29);
             this.mAnimationTrackBar.TabIndex = 1;
-            // 
-            // convertAnimationsToP5InDirectoryToolStripMenuItem
-            // 
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Name = "convertAnimationsToP5InDirectoryToolStripMenuItem";
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Size = new System.Drawing.Size(327, 22);
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Text = "Convert P5R animations to P5 in directory";
-            this.convertAnimationsToP5InDirectoryToolStripMenuItem.Click += new System.EventHandler(this.HandleConvertAnimationsToolStripMenuItemClick);
             // 
             // MainForm
             // 
@@ -356,5 +365,6 @@ namespace GFDStudio.GUI.Forms
         private System.Windows.Forms.Button mAnimationStopButton;
         private System.Windows.Forms.ToolStripMenuItem rescaleAnimationPacksInDirectoryToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem convertAnimationsToP5InDirectoryToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem convertMaterialInDirectoryToolStripMenuItem;
     }
 }

--- a/GFDStudio/GUI/Forms/MainForm.Events.cs
+++ b/GFDStudio/GUI/Forms/MainForm.Events.cs
@@ -355,9 +355,8 @@ namespace GFDStudio.GUI.Forms
                         try
                         {
                             var materialDictionary = Resource.Load<MaterialDictionary>(filePath);
-                            Console.WriteLine(materialDictionary);
-                            //materialDictionary.ReplaceWith (MaterialDictionary.ConvertToMaterialPreset(materialDictionary, option));
-                            //materialDictionary.Save(filePath);
+                            materialDictionary.ReplaceWith (MaterialDictionary.ConvertToMaterialPreset(materialDictionary, option));
+                            materialDictionary.Save(filePath);
                         }
                         catch (Exception)
                         {

--- a/GFDStudio/GUI/Forms/MainForm.Events.cs
+++ b/GFDStudio/GUI/Forms/MainForm.Events.cs
@@ -352,9 +352,11 @@ namespace GFDStudio.GUI.Forms
 
                         try
                         {
-                            var materialDictionary = Resource.Load<MaterialDictionary>(filePath);
-                            materialDictionary.ReplaceWith (MaterialDictionary.ConvertToMaterialPreset(materialDictionary, option));
-                            materialDictionary.Save(filePath);
+                            var model = Resource.Load<ModelPack>(filePath);
+                            var materials = model.Materials;
+                            var materialsConverted = MaterialDictionary.ConvertToMaterialPreset(materials, option);
+                            model.Materials = materialsConverted;
+                            model.Save(filePath);
                         }
                         catch (Exception)
                         {

--- a/GFDStudio/GUI/Forms/MainForm.Events.cs
+++ b/GFDStudio/GUI/Forms/MainForm.Events.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Numerics;


### PR DESCRIPTION
A new feature that allows you to convert a model's material to the preset one. Useful for converting P5R materials or adding a blue glow effect for custom personas.
To use it, right click on the material parent folder, select Convert to -> Material preset, and choose the preset.
Currently the batch conversion isn't working because I'm dumb lol.