### PR TITLE
Added Expand All Nodes Feature and Renamed Field0C

### DIFF
--- a/GFDLibrary/Materials/MaterialAttribute.cs
+++ b/GFDLibrary/Materials/MaterialAttribute.cs
@@ -264,7 +264,7 @@ namespace GFDLibrary.Materials
     public sealed class MaterialAttributeType1 : MaterialAttribute
     {
         // 10
-        public Vector4 Field0C { get; set; }
+        public Vector4 InnerGlow { get; set; }
 
         // 1C
         public float Field1C { get; set; }
@@ -294,7 +294,7 @@ namespace GFDLibrary.Materials
 
         internal override void Read( ResourceReader reader, long endPosition = -1 )
         {
-            Field0C = reader.ReadVector4();
+            InnerGlow = reader.ReadVector4();
             Field1C = reader.ReadSingle();
             Field20 = reader.ReadSingle();
             Field24 = reader.ReadVector4();
@@ -332,7 +332,7 @@ namespace GFDLibrary.Materials
 
         internal override void Write( ResourceWriter writer )
         {
-            writer.WriteVector4( Field0C );
+            writer.WriteVector4( InnerGlow );
             writer.WriteSingle( Field1C );
             writer.WriteSingle( Field20 );
             writer.WriteVector4( Field24 );

--- a/GFDLibrary/Materials/MaterialFactory.cs
+++ b/GFDLibrary/Materials/MaterialFactory.cs
@@ -170,7 +170,7 @@ namespace GFDLibrary.Materials
                     },
                     new MaterialAttributeType2
                     {
-                        InnerGlow = 1,
+                        Field0C = 1,
                         Field10 = 121,
                         Flags = MaterialAttributeFlags.Flag1
                     }

--- a/GFDLibrary/Materials/MaterialFactory.cs
+++ b/GFDLibrary/Materials/MaterialFactory.cs
@@ -159,7 +159,7 @@ namespace GFDLibrary.Materials
                 {
                     new MaterialAttributeType1
                     {
-                        Field0C = new Vector4(0.2352941f, 0.5960785f, 1, 1),
+                        InnerGlow = new Vector4(0.2352941f, 0.5960785f, 1, 1),
                         Field1C = 0.85f,
                         Field20 = 2,
                         Field24 = new Vector4(0, 0, 0, 0),
@@ -170,7 +170,7 @@ namespace GFDLibrary.Materials
                     },
                     new MaterialAttributeType2
                     {
-                        Field0C = 1,
+                        InnerGlow = 1,
                         Field10 = 121,
                         Flags = MaterialAttributeFlags.Flag1
                     }

--- a/GFDStudio/GUI/DataViewNodes/DataViewNode.cs
+++ b/GFDStudio/GUI/DataViewNodes/DataViewNode.cs
@@ -377,10 +377,11 @@ namespace GFDStudio.GUI.DataViewNodes
                 DataTreeView.SelectedNode = this;
         }
 
-        public void Expand()
+        //
+        // Expand all nodes method
+        //
+        public void ExpandAllNodes()
         {
-
-            // Expand all nodes
             DataTreeView.ExpandAll();
             DataTreeView.Nodes[0].EnsureVisible();
         }
@@ -715,7 +716,7 @@ namespace GFDStudio.GUI.DataViewNodes
 
             if (ContextMenuFlags.HasFlag(DataViewNodeMenuFlags.Expand))
             {
-                ContextMenuStrip.Items.Add(new ToolStripMenuItem("&Expand", null, CreateEventHandler(() => Expand()), Keys.Control | Keys.A)
+                ContextMenuStrip.Items.Add(new ToolStripMenuItem("&Expand All", null, CreateEventHandler(() => ExpandAllNodes()), Keys.Control | Keys.A)
                 {
                     Name = "Expand All"
                 });

--- a/GFDStudio/GUI/DataViewNodes/DataViewNode.cs
+++ b/GFDStudio/GUI/DataViewNodes/DataViewNode.cs
@@ -377,6 +377,14 @@ namespace GFDStudio.GUI.DataViewNodes
                 DataTreeView.SelectedNode = this;
         }
 
+        public void Expand()
+        {
+
+            // Expand all nodes
+            DataTreeView.ExpandAll();
+            DataTreeView.Nodes[0].EnsureVisible();
+        }
+
         //
         // Delete method
         //
@@ -705,6 +713,14 @@ namespace GFDStudio.GUI.DataViewNodes
                 });
             }
 
+            if (ContextMenuFlags.HasFlag(DataViewNodeMenuFlags.Expand))
+            {
+                ContextMenuStrip.Items.Add(new ToolStripMenuItem("&Expand", null, CreateEventHandler(() => Expand()), Keys.Control | Keys.A)
+                {
+                    Name = "Expand All"
+                });
+            }
+
             foreach ( (string menuPath, ToolStripMenuItem item) in mCustomHandlers.Where( x => x.Menu != null ) )
             {
                 // Add custom handlers with a menu path
@@ -840,5 +856,6 @@ namespace GFDStudio.GUI.DataViewNodes
         Move = 0b00001000,
         Rename = 0b00010000,
         Delete = 0b00100000,
+        Expand = 0b01000000,
     }
 }

--- a/GFDStudio/GUI/DataViewNodes/MaterialAttributeType1ViewNode.cs
+++ b/GFDStudio/GUI/DataViewNodes/MaterialAttributeType1ViewNode.cs
@@ -18,7 +18,8 @@ namespace GFDStudio.GUI.DataViewNodes
         // 0C
         [ Browsable( true ) ]
         [ TypeConverter( typeof( Vector4TypeConverter ) ) ]
-        public Vector4 Field0C
+        [DisplayName("Inner Glow")]
+        public Vector4 InnerGlow
         {
             get => GetDataProperty<Vector4>();
             set => SetDataProperty( value );

--- a/GFDStudio/GUI/DataViewNodes/ModelPackViewNode.cs
+++ b/GFDStudio/GUI/DataViewNodes/ModelPackViewNode.cs
@@ -13,7 +13,8 @@ namespace GFDStudio.GUI.DataViewNodes
     {
         public override DataViewNodeMenuFlags ContextMenuFlags =>
             DataViewNodeMenuFlags.Export | DataViewNodeMenuFlags.Replace |
-            DataViewNodeMenuFlags.Move | DataViewNodeMenuFlags.Delete;
+            DataViewNodeMenuFlags.Move | DataViewNodeMenuFlags.Delete |
+            DataViewNodeMenuFlags.Expand;
 
         public override DataViewNodeFlags NodeFlags => DataViewNodeFlags.Branch;
 


### PR DESCRIPTION
- Added Expand All feature to ModelPackViewNode to expand every single node since it can be annoying to expand them all manually
- Renamed Field0C in MaterialAttributeType1 to Inner Glow as per Issue #25 